### PR TITLE
Fix permission failure

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,6 +17,8 @@
 homepage: "https://bambuser.com"
 documentation: "https://bambuser.com/docs"
 versions:
+  - sha: d0b0dbe7b0e5d50b96c6505a868a026f534d50f9
+    changeNotes: Call gtmOnFailure when missing required permissions
   - sha: b70dcb1c4f7aa831954d0d57c346fbcaa87a829a
     changeNotes: Add support to pass in customer data
   - sha: db48db08212ea50d331b6315aac175186bb0af93

--- a/template.tpl
+++ b/template.tpl
@@ -205,9 +205,13 @@ if (!!customerInfo) {
 }
 
 const launch = function (debugMode) {
-  const oneToOneEmbed = callInWindow('launchBambuserOneToOne', conf, debugMode);
-  log('successfully created one-to-one instance');
-  data.gtmOnSuccess();
+  if (queryPermission('access_globals', 'execute', 'launchBambuserOneToOne')) {
+    const oneToOneEmbed = callInWindow('launchBambuserOneToOne', conf, debugMode);
+    log('successfully created one-to-one instance');
+    data.gtmOnSuccess();
+  } else {
+    data.gtmOnFailure();
+  }
 };
 
 const url = 'https://one-to-one.bambuser.com/embed.js';

--- a/template.tpl
+++ b/template.tpl
@@ -223,6 +223,8 @@ if (queryPermission('inject_script', url)) {
       data.gtmOnFailure();
     }
   );
+} else {
+  data.gtmOnFailure();
 }
 
 return conf;


### PR DESCRIPTION
This PR makes sure we call gtmOnFailure when the tag is missing the required permissions. 
Came up in issue https://github.com/bambuser/bambuser-one-to-one-gtm-template/issues/2